### PR TITLE
Update Reskillable Integration

### DIFF
--- a/src/main/java/com/buuz135/togetherforever/TogetherForever.java
+++ b/src/main/java/com/buuz135/togetherforever/TogetherForever.java
@@ -38,7 +38,7 @@ import java.util.List;
         modid = TogetherForever.MOD_ID,
         name = TogetherForever.MOD_NAME,
         version = TogetherForever.VERSION,
-        dependencies = "required:forge@[14.23.1.2560,);after:gamestages@[1.0.76,);"
+        dependencies = "required:forge@[14.23.1.2560,);after:gamestages@[1.0.76,);after:reskillable@[1.7.0,);"
 )
 public class TogetherForever {
 

--- a/src/main/java/com/buuz135/togetherforever/action/recovery/ReskillableLevelUpOfflineRecovery.java
+++ b/src/main/java/com/buuz135/togetherforever/action/recovery/ReskillableLevelUpOfflineRecovery.java
@@ -3,6 +3,8 @@ package com.buuz135.togetherforever.action.recovery;
 import codersafterdark.reskillable.api.ReskillableRegistries;
 import codersafterdark.reskillable.api.data.PlayerData;
 import codersafterdark.reskillable.api.data.PlayerDataHandler;
+import codersafterdark.reskillable.api.requirement.RequirementCache;
+import codersafterdark.reskillable.api.requirement.SkillRequirement;
 import codersafterdark.reskillable.api.skill.Skill;
 import com.buuz135.togetherforever.api.IOfflineSyncRecovery;
 import com.buuz135.togetherforever.api.IPlayerInformation;
@@ -47,6 +49,7 @@ public class ReskillableLevelUpOfflineRecovery implements IOfflineSyncRecovery {
                     PlayerData data = PlayerDataHandler.get(playerInformation.getPlayer());
                     data.getSkillInfo(skill).levelUp();
                     data.saveAndSync();
+                    RequirementCache.invalidateCache(playerInformation.getUUID(), SkillRequirement.class);
                 }
                 removeList.add(entry);
             }

--- a/src/main/java/com/buuz135/togetherforever/action/recovery/ReskillableUnlockableOfflineRecovery.java
+++ b/src/main/java/com/buuz135/togetherforever/action/recovery/ReskillableUnlockableOfflineRecovery.java
@@ -3,6 +3,8 @@ package com.buuz135.togetherforever.action.recovery;
 import codersafterdark.reskillable.api.ReskillableRegistries;
 import codersafterdark.reskillable.api.data.PlayerData;
 import codersafterdark.reskillable.api.data.PlayerDataHandler;
+import codersafterdark.reskillable.api.requirement.RequirementCache;
+import codersafterdark.reskillable.api.requirement.TraitRequirement;
 import codersafterdark.reskillable.api.unlockable.Unlockable;
 import com.buuz135.togetherforever.api.IOfflineSyncRecovery;
 import com.buuz135.togetherforever.api.IPlayerInformation;
@@ -48,6 +50,7 @@ public class ReskillableUnlockableOfflineRecovery implements IOfflineSyncRecover
                     if (data != null && !data.getSkillInfo(unlockable.getParentSkill()).isUnlocked(unlockable)) {
                         data.getSkillInfo(unlockable.getParentSkill()).unlock(unlockable, playerInformation.getPlayer());
                         data.saveAndSync();
+                        RequirementCache.invalidateCache(playerInformation.getUUID(), TraitRequirement.class);
                     }
                 }
                 removeList.add(entry);


### PR DESCRIPTION
- Invalidate RequirementCache of updated player. This lets Reskillable know it needs to recheck the requirements of that player next time they are requested.
- Uses the `setLevel` method in PlayerSkillInfo instead of having to call `levelUp` multiple times.