### PR TITLE
Code Cleanup and Reskillable integration improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ repositories {
 dependencies {
     deobfCompile "net.darkhax.bookshelf:Bookshelf-1.12.2:${version_bookshelf}"
     deobfCompile "net.darkhax.gamestages:GameStages-1.12.2:${version_gamestages}"
-    deobfCompile "codersafterdark.reskillable:Reskillable:1.12.2+"
+    deobfCompile "codersafterdark.reskillable:Reskillable:1.12.2-1.9.1-SNAPSHOT.93"
 }
 
 processResources {

--- a/src/main/java/com/buuz135/togetherforever/TogetherForever.java
+++ b/src/main/java/com/buuz135/togetherforever/TogetherForever.java
@@ -48,7 +48,7 @@ public class TogetherForever {
 
     public static Logger LOGGER;
 
-    //Add a comand to force sync players
+    //Add a command to force sync players
     //Sync other player stuff when player joins
     /**
      * This is the instance of your mod as created by Forge. It will never be null.

--- a/src/main/java/com/buuz135/togetherforever/TogetherForever.java
+++ b/src/main/java/com/buuz135/togetherforever/TogetherForever.java
@@ -38,7 +38,7 @@ import java.util.List;
         modid = TogetherForever.MOD_ID,
         name = TogetherForever.MOD_NAME,
         version = TogetherForever.VERSION,
-        dependencies = "required:forge@[14.23.1.2560,);after:gamestages@[2.0.90,);after:reskillable@[1.7.0,);"
+        dependencies = "required:forge@[14.23.1.2560,);after:gamestages@[2.0.90,);after:reskillable@[1.9.1,);"
 )
 public class TogetherForever {
 

--- a/src/main/java/com/buuz135/togetherforever/TogetherForever.java
+++ b/src/main/java/com/buuz135/togetherforever/TogetherForever.java
@@ -130,9 +130,9 @@ public class TogetherForever {
     }
 
     private void registerSyncActions(ASMDataTable data) throws IllegalAccessException, InstantiationException {
-        for (Class aClass : AnnotationHelper.getAnnotatedClasses(data, SyncAction.class)) {
+        for (Class<?> aClass : AnnotationHelper.getAnnotatedClasses(data, SyncAction.class)) {
             if (ISyncAction.class.isAssignableFrom(aClass)) {
-                SyncAction syncAction = (SyncAction) aClass.getAnnotation(SyncAction.class);
+                SyncAction syncAction = aClass.getAnnotation(SyncAction.class);
                 if (syncAction.dependencies().length == 0 || areDependenciesLoaded(syncAction.dependencies())) {
                     Object object = aClass.newInstance();
                     TogetherRegistries.registerSyncAction(syncAction.id(), (ISyncAction) object);

--- a/src/main/java/com/buuz135/togetherforever/TogetherForever.java
+++ b/src/main/java/com/buuz135/togetherforever/TogetherForever.java
@@ -135,7 +135,7 @@ public class TogetherForever {
                 SyncAction syncAction = aClass.getAnnotation(SyncAction.class);
                 if (syncAction.dependencies().length == 0 || areDependenciesLoaded(syncAction.dependencies())) {
                     Object object = aClass.newInstance();
-                    TogetherRegistries.registerSyncAction(syncAction.id(), (ISyncAction) object);
+                    TogetherRegistries.registerSyncAction(syncAction.id(), (ISyncAction<?, ? extends IOfflineSyncRecovery>) object);
                 }
             }
         }

--- a/src/main/java/com/buuz135/togetherforever/action/AdvancementEventSyncAction.java
+++ b/src/main/java/com/buuz135/togetherforever/action/AdvancementEventSyncAction.java
@@ -24,7 +24,7 @@ public class AdvancementEventSyncAction extends EventSyncAction<AdvancementEvent
 
     public static void grantAllParentAchievements(EntityPlayerMP player, Advancement advancement) {
         if (advancement.getParent() != null) grantAllParentAchievements(player, advancement.getParent());
-        TogetherForever.LOGGER.warn("Advancement granting: " + advancement.getId().toString());
+        TogetherForever.LOGGER.debug("Advancement granting: " + advancement.getId().toString());
         for (String string : player.getAdvancements().getProgress(advancement).getRemaningCriteria()) {
             player.getAdvancements().grantCriterion(advancement, string);
         }
@@ -33,16 +33,16 @@ public class AdvancementEventSyncAction extends EventSyncAction<AdvancementEvent
     @Override
     public List<IPlayerInformation> triggerSync(AdvancementEvent object, ITogetherTeam togetherTeam) {
         List<IPlayerInformation> playerInformations = new ArrayList<>();
-        TogetherForever.LOGGER.warn("Starting to sync advancement " + object.getAdvancement().getId().toString());
+        TogetherForever.LOGGER.debug("Starting to sync advancement " + object.getAdvancement().getId().toString());
         if (!TogetherForeverConfig.advancementSync) return playerInformations;
         for (IPlayerInformation information : togetherTeam.getPlayers()) {
             EntityPlayerMP playerMP = information.getPlayer();
             if (playerMP == null) {
-                TogetherForever.LOGGER.warn(information.getName() + " is not online, adding it to the offline recovery!");
+                TogetherForever.LOGGER.debug(information.getName() + " is not online, adding it to the offline recovery!");
                 playerInformations.add(information);
             }
             else {
-                TogetherForever.LOGGER.warn("Trying to grant all the parent advancements to the player " + information.getName());
+                TogetherForever.LOGGER.debug("Trying to grant all the parent advancements to the player " + information.getName());
                 grantAllParentAchievements(playerMP, object.getAdvancement());
             }
         }

--- a/src/main/java/com/buuz135/togetherforever/action/ReskillableLevelUpEventSyncAction.java
+++ b/src/main/java/com/buuz135/togetherforever/action/ReskillableLevelUpEventSyncAction.java
@@ -31,9 +31,7 @@ public class ReskillableLevelUpEventSyncAction extends EventSyncAction<LevelUpEv
     public NBTTagCompound transformEventToNBT(LevelUpEvent.Post event) {
         NBTTagCompound tagCompound = new NBTTagCompound();
         tagCompound.setString("Skill", event.getSkill().getRegistryName().toString());
-        if (event.getLevel() - event.getOldLevel() > 0) {
-            tagCompound.setInteger("NewLevel", event.getLevel());
-        }
+        tagCompound.setInteger("NewLevel", event.getLevel());
         return tagCompound;
     }
 

--- a/src/main/java/com/buuz135/togetherforever/action/ReskillableLevelUpEventSyncAction.java
+++ b/src/main/java/com/buuz135/togetherforever/action/ReskillableLevelUpEventSyncAction.java
@@ -8,6 +8,7 @@ import codersafterdark.reskillable.api.event.LevelUpEvent;
 import codersafterdark.reskillable.api.requirement.RequirementCache;
 import codersafterdark.reskillable.api.requirement.SkillRequirement;
 import codersafterdark.reskillable.api.skill.Skill;
+import codersafterdark.reskillable.api.toast.ToastHelper;
 import com.buuz135.togetherforever.action.recovery.ReskillableLevelUpOfflineRecovery;
 import com.buuz135.togetherforever.api.IPlayerInformation;
 import com.buuz135.togetherforever.api.ITogetherTeam;
@@ -45,15 +46,14 @@ public class ReskillableLevelUpEventSyncAction extends EventSyncAction<LevelUpEv
             else {
                 if (playerMP.getUniqueID().equals(object.getEntityPlayer().getUniqueID())) continue;
                 PlayerData data = PlayerDataHandler.get(playerMP);
-                PlayerSkillInfo skillInfo = data.getSkillInfo(object.getSkill());
-                boolean changed = false;
-                if (skillInfo.getLevel() < object.getLevel()) {
-                    skillInfo.setLevel(object.getLevel());
-                    changed = true;
-                }
-                if (changed) {
+                Skill skill = object.getSkill();
+                PlayerSkillInfo skillInfo = data.getSkillInfo(skill);
+                int level = object.getLevel();
+                if (skillInfo.getLevel() < level) {
+                    skillInfo.setLevel(level);
                     data.saveAndSync();
                     RequirementCache.invalidateCache(information.getUUID(), SkillRequirement.class);
+                    ToastHelper.sendSkillToast(playerMP, skill, level);
                 }
             }
         }
@@ -72,6 +72,7 @@ public class ReskillableLevelUpEventSyncAction extends EventSyncAction<LevelUpEv
                 if (skillInfo.getLevel() < otherLevel) {
                     skillInfo.setLevel(otherLevel);
                     changed = true;
+                    ToastHelper.sendSkillToast(toBeSynced.getPlayer(), skill, otherLevel);
                 }
             }
             if (changed) {

--- a/src/main/java/com/buuz135/togetherforever/action/ReskillableLevelUpEventSyncAction.java
+++ b/src/main/java/com/buuz135/togetherforever/action/ReskillableLevelUpEventSyncAction.java
@@ -31,6 +31,9 @@ public class ReskillableLevelUpEventSyncAction extends EventSyncAction<LevelUpEv
     public NBTTagCompound transformEventToNBT(LevelUpEvent.Post event) {
         NBTTagCompound tagCompound = new NBTTagCompound();
         tagCompound.setString("Skill", event.getSkill().getRegistryName().toString());
+        if (event.getLevel() - event.getOldLevel() > 0) {
+            tagCompound.setInteger("NewLevel", event.getLevel());
+        }
         return tagCompound;
     }
 

--- a/src/main/java/com/buuz135/togetherforever/action/ReskillableLevelUpEventSyncAction.java
+++ b/src/main/java/com/buuz135/togetherforever/action/ReskillableLevelUpEventSyncAction.java
@@ -51,8 +51,8 @@ public class ReskillableLevelUpEventSyncAction extends EventSyncAction<LevelUpEv
                     skillInfo.setLevel(object.getLevel());
                     changed = true;
                 }
-                data.saveAndSync();
                 if (changed) {
+                    data.saveAndSync();
                     RequirementCache.invalidateCache(information.getUUID(), SkillRequirement.class);
                 }
             }
@@ -74,8 +74,8 @@ public class ReskillableLevelUpEventSyncAction extends EventSyncAction<LevelUpEv
                     changed = true;
                 }
             }
-            sync.saveAndSync();
             if (changed) {
+                sync.saveAndSync();
                 RequirementCache.invalidateCache(toBeSynced.getUUID(), SkillRequirement.class);
             }
             origin.saveAndSync();

--- a/src/main/java/com/buuz135/togetherforever/action/ReskillableUnlockableSyncAction.java
+++ b/src/main/java/com/buuz135/togetherforever/action/ReskillableUnlockableSyncAction.java
@@ -45,8 +45,9 @@ public class ReskillableUnlockableSyncAction extends EventSyncAction<UnlockUnloc
             else {
                 if (playerMP.getUniqueID().equals(object.getEntityPlayer().getUniqueID())) continue;
                 PlayerData data = PlayerDataHandler.get(playerMP);
-                if (!data.getSkillInfo(object.getUnlockable().getParentSkill()).isUnlocked(object.getUnlockable())) {
-                    data.getSkillInfo(object.getUnlockable().getParentSkill()).unlock(object.getUnlockable(), playerMP);
+                PlayerSkillInfo skillInfo = data.getSkillInfo(object.getUnlockable().getParentSkill());
+                if (!skillInfo.isUnlocked(object.getUnlockable())) {
+                    skillInfo.unlock(object.getUnlockable(), playerMP);
                     data.saveAndSync();
                     RequirementCache.invalidateCache(information.getUUID(), TraitRequirement.class);
                 }
@@ -71,8 +72,8 @@ public class ReskillableUnlockableSyncAction extends EventSyncAction<UnlockUnloc
                     }
                 }
             }
-            sync.saveAndSync();
             if (changed) {
+                sync.saveAndSync();
                 RequirementCache.invalidateCache(toBeSynced.getUUID(), TraitRequirement.class);
             }
             origin.saveAndSync();

--- a/src/main/java/com/buuz135/togetherforever/action/ReskillableUnlockableSyncAction.java
+++ b/src/main/java/com/buuz135/togetherforever/action/ReskillableUnlockableSyncAction.java
@@ -8,6 +8,7 @@ import codersafterdark.reskillable.api.event.UnlockUnlockableEvent;
 import codersafterdark.reskillable.api.requirement.RequirementCache;
 import codersafterdark.reskillable.api.requirement.TraitRequirement;
 import codersafterdark.reskillable.api.skill.Skill;
+import codersafterdark.reskillable.api.toast.ToastHelper;
 import codersafterdark.reskillable.api.unlockable.Unlockable;
 import com.buuz135.togetherforever.action.recovery.ReskillableUnlockableOfflineRecovery;
 import com.buuz135.togetherforever.api.IPlayerInformation;
@@ -45,11 +46,13 @@ public class ReskillableUnlockableSyncAction extends EventSyncAction<UnlockUnloc
             else {
                 if (playerMP.getUniqueID().equals(object.getEntityPlayer().getUniqueID())) continue;
                 PlayerData data = PlayerDataHandler.get(playerMP);
-                PlayerSkillInfo skillInfo = data.getSkillInfo(object.getUnlockable().getParentSkill());
-                if (!skillInfo.isUnlocked(object.getUnlockable())) {
-                    skillInfo.unlock(object.getUnlockable(), playerMP);
+                Unlockable unlockable = object.getUnlockable();
+                PlayerSkillInfo skillInfo = data.getSkillInfo(unlockable.getParentSkill());
+                if (!skillInfo.isUnlocked(unlockable)) {
+                    skillInfo.unlock(unlockable, playerMP);
                     data.saveAndSync();
                     RequirementCache.invalidateCache(information.getUUID(), TraitRequirement.class);
+                    ToastHelper.sendUnlockableToast(information.getPlayer(), unlockable);
                 }
             }
         }
@@ -69,6 +72,7 @@ public class ReskillableUnlockableSyncAction extends EventSyncAction<UnlockUnloc
                     if (originSkillInfo.isUnlocked(unlockable) && !syncSkillInfo.isUnlocked(unlockable)) {
                         syncSkillInfo.unlock(unlockable, toBeSynced.getPlayer());
                         changed = true;
+                        ToastHelper.sendUnlockableToast(toBeSynced.getPlayer(), unlockable);
                     }
                 }
             }

--- a/src/main/java/com/buuz135/togetherforever/action/recovery/AbstractOfflineRecovery.java
+++ b/src/main/java/com/buuz135/togetherforever/action/recovery/AbstractOfflineRecovery.java
@@ -1,0 +1,70 @@
+package com.buuz135.togetherforever.action.recovery;
+
+import com.buuz135.togetherforever.api.IOfflineSyncRecovery;
+import com.buuz135.togetherforever.api.IPlayerInformation;
+import com.buuz135.togetherforever.api.data.TogetherRegistries;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ListMultimap;
+import net.minecraft.nbt.NBTTagCompound;
+
+import java.util.List;
+
+public abstract class AbstractOfflineRecovery implements IOfflineSyncRecovery {
+    protected ListMultimap<IPlayerInformation, NBTTagCompound> offlineRecoveries;
+
+    public AbstractOfflineRecovery() {
+        this.offlineRecoveries = ArrayListMultimap.create();
+    }
+
+    @Override
+    public void storeMissingPlayers(List<IPlayerInformation> playersInformation, NBTTagCompound store) {
+        for (IPlayerInformation playerInformation : playersInformation) {
+            storeMissingPlayer(playerInformation, store);
+        }
+    }
+
+    @Override
+    public void storeMissingPlayer(IPlayerInformation playerInformation, NBTTagCompound store) {
+        offlineRecoveries.put(playerInformation, store);
+    }
+
+    @Override
+    public NBTTagCompound writeToNBT() {
+        NBTTagCompound tagCompound = new NBTTagCompound();
+        for (IPlayerInformation playerInformation : offlineRecoveries.keySet()) {
+            String uuid = playerInformation.getUUID().toString();
+            NBTTagCompound recovery = new NBTTagCompound();
+            recovery.setTag("ID", playerInformation.getNBTTag());
+            recovery.setString("PlayerID", TogetherRegistries.getPlayerInformationID(playerInformation.getClass()));
+            int id = 0;
+            for (NBTTagCompound compound : offlineRecoveries.get(playerInformation)) {
+                recovery.setTag(Integer.toString(id), compound);
+                ++id;
+            }
+            tagCompound.setTag(uuid, recovery);
+        }
+        return tagCompound;
+    }
+
+    @Override
+    public void readFromNBT(NBTTagCompound compound) {
+        offlineRecoveries.clear();
+        for (String uuid : compound.getKeySet()) {
+            NBTTagCompound recovery = compound.getCompoundTag(uuid);
+            Class<? extends IPlayerInformation> plClass = TogetherRegistries.getPlayerInformationClass(recovery.getString("PlayerID"));
+            if (plClass != null) {
+                try {
+                    IPlayerInformation info = plClass.newInstance();
+                    info.readFromNBT(recovery.getCompoundTag("ID"));
+                    for (String id : recovery.getKeySet()) {
+                        if (!id.equalsIgnoreCase("ID") && !id.equalsIgnoreCase("PlayerID")) {
+                            offlineRecoveries.put(info, recovery.getCompoundTag(id));
+                        }
+                    }
+                } catch (InstantiationException | IllegalAccessException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/buuz135/togetherforever/action/recovery/AdvancementOfflineRecovery.java
+++ b/src/main/java/com/buuz135/togetherforever/action/recovery/AdvancementOfflineRecovery.java
@@ -63,7 +63,7 @@ public class AdvancementOfflineRecovery implements IOfflineSyncRecovery {
             recovery.setString("PlayerID", TogetherRegistries.getPlayerInformationID(playerInformation.getClass()));
             int id = 0;
             for (NBTTagCompound compound : offlineRecoveries.get(playerInformation)) {
-                recovery.setTag(id + "", compound);
+                recovery.setTag(Integer.toString(id), compound);
                 ++id;
             }
             tagCompound.setTag(uuid, recovery);
@@ -76,10 +76,10 @@ public class AdvancementOfflineRecovery implements IOfflineSyncRecovery {
         offlineRecoveries.clear();
         for (String uuid : compound.getKeySet()) {
             NBTTagCompound recovery = compound.getCompoundTag(uuid);
-            Class plClass = TogetherRegistries.getPlayerInformationClass(recovery.getString("PlayerID"));
+            Class<? extends IPlayerInformation> plClass = TogetherRegistries.getPlayerInformationClass(recovery.getString("PlayerID"));
             if (plClass != null) {
                 try {
-                    IPlayerInformation info = (IPlayerInformation) plClass.newInstance();
+                    IPlayerInformation info = plClass.newInstance();
                     info.readFromNBT(recovery.getCompoundTag("ID"));
                     for (String id : recovery.getKeySet()) {
                         if (!id.equalsIgnoreCase("ID") && !id.equalsIgnoreCase("PlayerID")) {

--- a/src/main/java/com/buuz135/togetherforever/action/recovery/GameStageOfflineRecovery.java
+++ b/src/main/java/com/buuz135/togetherforever/action/recovery/GameStageOfflineRecovery.java
@@ -1,11 +1,7 @@
 package com.buuz135.togetherforever.action.recovery;
 
 import com.buuz135.togetherforever.action.GameStagesEventSyncAction;
-import com.buuz135.togetherforever.api.IOfflineSyncRecovery;
 import com.buuz135.togetherforever.api.IPlayerInformation;
-import com.buuz135.togetherforever.api.data.TogetherRegistries;
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.ListMultimap;
 import net.darkhax.gamestages.GameStageHelper;
 import net.minecraft.nbt.NBTTagCompound;
 
@@ -13,24 +9,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-public class GameStageOfflineRecovery implements IOfflineSyncRecovery {
-
-    private ListMultimap<IPlayerInformation, NBTTagCompound> offlineRecoveries;
-
+public class GameStageOfflineRecovery extends AbstractOfflineRecovery {
     public GameStageOfflineRecovery() {
-        this.offlineRecoveries = ArrayListMultimap.create();
-    }
-
-    @Override
-    public void storeMissingPlayers(List<IPlayerInformation> playerInformations, NBTTagCompound store) {
-        for (IPlayerInformation playerInformation : playerInformations) {
-            storeMissingPlayer(playerInformation, store);
-        }
-    }
-
-    @Override
-    public void storeMissingPlayer(IPlayerInformation playerInformation, NBTTagCompound store) {
-        offlineRecoveries.put(playerInformation, store);
+        super();
     }
 
     @Override
@@ -47,46 +28,6 @@ public class GameStageOfflineRecovery implements IOfflineSyncRecovery {
         }
         for (Map.Entry<IPlayerInformation, NBTTagCompound> entry : removeList) {
             offlineRecoveries.remove(entry.getKey(), entry.getValue());
-        }
-    }
-
-    @Override
-    public NBTTagCompound writeToNBT() {
-        NBTTagCompound tagCompound = new NBTTagCompound();
-        for (IPlayerInformation playerInformation : offlineRecoveries.keySet()) {
-            String uuid = playerInformation.getUUID().toString();
-            NBTTagCompound recovery = new NBTTagCompound();
-            recovery.setTag("ID", playerInformation.getNBTTag());
-            recovery.setString("PlayerID", TogetherRegistries.getPlayerInformationID(playerInformation.getClass()));
-            int id = 0;
-            for (NBTTagCompound compound : offlineRecoveries.get(playerInformation)) {
-                recovery.setTag(Integer.toString(id), compound);
-                ++id;
-            }
-            tagCompound.setTag(uuid, recovery);
-        }
-        return tagCompound;
-    }
-
-    @Override
-    public void readFromNBT(NBTTagCompound compound) {
-        offlineRecoveries.clear();
-        for (String uuid : compound.getKeySet()) {
-            NBTTagCompound recovery = compound.getCompoundTag(uuid);
-            Class<? extends IPlayerInformation> plClass = TogetherRegistries.getPlayerInformationClass(recovery.getString("PlayerID"));
-            if (plClass != null) {
-                try {
-                    IPlayerInformation info = plClass.newInstance();
-                    info.readFromNBT(recovery.getCompoundTag("ID"));
-                    for (String id : recovery.getKeySet()) {
-                        if (!id.equalsIgnoreCase("ID") && !id.equalsIgnoreCase("PlayerID")) {
-                            offlineRecoveries.put(info, recovery.getCompoundTag(id));
-                        }
-                    }
-                } catch (InstantiationException | IllegalAccessException e) {
-                    e.printStackTrace();
-                }
-            }
         }
     }
 }

--- a/src/main/java/com/buuz135/togetherforever/action/recovery/GameStageOfflineRecovery.java
+++ b/src/main/java/com/buuz135/togetherforever/action/recovery/GameStageOfflineRecovery.java
@@ -60,7 +60,7 @@ public class GameStageOfflineRecovery implements IOfflineSyncRecovery {
             recovery.setString("PlayerID", TogetherRegistries.getPlayerInformationID(playerInformation.getClass()));
             int id = 0;
             for (NBTTagCompound compound : offlineRecoveries.get(playerInformation)) {
-                recovery.setTag(id + "", compound);
+                recovery.setTag(Integer.toString(id), compound);
                 ++id;
             }
             tagCompound.setTag(uuid, recovery);
@@ -73,10 +73,10 @@ public class GameStageOfflineRecovery implements IOfflineSyncRecovery {
         offlineRecoveries.clear();
         for (String uuid : compound.getKeySet()) {
             NBTTagCompound recovery = compound.getCompoundTag(uuid);
-            Class plClass = TogetherRegistries.getPlayerInformationClass(recovery.getString("PlayerID"));
+            Class<? extends IPlayerInformation> plClass = TogetherRegistries.getPlayerInformationClass(recovery.getString("PlayerID"));
             if (plClass != null) {
                 try {
-                    IPlayerInformation info = (IPlayerInformation) plClass.newInstance();
+                    IPlayerInformation info = plClass.newInstance();
                     info.readFromNBT(recovery.getCompoundTag("ID"));
                     for (String id : recovery.getKeySet()) {
                         if (!id.equalsIgnoreCase("ID") && !id.equalsIgnoreCase("PlayerID")) {

--- a/src/main/java/com/buuz135/togetherforever/action/recovery/ReskillableLevelUpOfflineRecovery.java
+++ b/src/main/java/com/buuz135/togetherforever/action/recovery/ReskillableLevelUpOfflineRecovery.java
@@ -6,11 +6,7 @@ import codersafterdark.reskillable.api.data.PlayerDataHandler;
 import codersafterdark.reskillable.api.requirement.RequirementCache;
 import codersafterdark.reskillable.api.requirement.SkillRequirement;
 import codersafterdark.reskillable.api.skill.Skill;
-import com.buuz135.togetherforever.api.IOfflineSyncRecovery;
 import com.buuz135.togetherforever.api.IPlayerInformation;
-import com.buuz135.togetherforever.api.data.TogetherRegistries;
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.ListMultimap;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ResourceLocation;
 
@@ -18,24 +14,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-public class ReskillableLevelUpOfflineRecovery implements IOfflineSyncRecovery {
-
-    private ListMultimap<IPlayerInformation, NBTTagCompound> offlineRecoveries;
-
+public class ReskillableLevelUpOfflineRecovery extends AbstractOfflineRecovery {
     public ReskillableLevelUpOfflineRecovery() {
-        this.offlineRecoveries = ArrayListMultimap.create();
-    }
-
-    @Override
-    public void storeMissingPlayers(List<IPlayerInformation> playersInformation, NBTTagCompound store) {
-        for (IPlayerInformation playerInformation : playersInformation) {
-            storeMissingPlayer(playerInformation, store);
-        }
-    }
-
-    @Override
-    public void storeMissingPlayer(IPlayerInformation playerInformation, NBTTagCompound store) {
-        offlineRecoveries.put(playerInformation, store);
+        super();
     }
 
     @Override
@@ -56,46 +37,6 @@ public class ReskillableLevelUpOfflineRecovery implements IOfflineSyncRecovery {
         }
         for (Map.Entry<IPlayerInformation, NBTTagCompound> entry : removeList) {
             offlineRecoveries.remove(entry.getKey(), entry.getValue());
-        }
-    }
-
-    @Override
-    public NBTTagCompound writeToNBT() {
-        NBTTagCompound tagCompound = new NBTTagCompound();
-        for (IPlayerInformation playerInformation : offlineRecoveries.keySet()) {
-            String uuid = playerInformation.getUUID().toString();
-            NBTTagCompound recovery = new NBTTagCompound();
-            recovery.setTag("ID", playerInformation.getNBTTag());
-            recovery.setString("PlayerID", TogetherRegistries.getPlayerInformationID(playerInformation.getClass()));
-            int id = 0;
-            for (NBTTagCompound compound : offlineRecoveries.get(playerInformation)) {
-                recovery.setTag(Integer.toString(id), compound);
-                ++id;
-            }
-            tagCompound.setTag(uuid, recovery);
-        }
-        return tagCompound;
-    }
-
-    @Override
-    public void readFromNBT(NBTTagCompound compound) {
-        offlineRecoveries.clear();
-        for (String uuid : compound.getKeySet()) {
-            NBTTagCompound recovery = compound.getCompoundTag(uuid);
-            Class<? extends IPlayerInformation> plClass = TogetherRegistries.getPlayerInformationClass(recovery.getString("PlayerID"));
-            if (plClass != null) {
-                try {
-                    IPlayerInformation info = plClass.newInstance();
-                    info.readFromNBT(recovery.getCompoundTag("ID"));
-                    for (String id : recovery.getKeySet()) {
-                        if (!id.equalsIgnoreCase("ID") && !id.equalsIgnoreCase("PlayerID")) {
-                            offlineRecoveries.put(info, recovery.getCompoundTag(id));
-                        }
-                    }
-                } catch (InstantiationException | IllegalAccessException e) {
-                    e.printStackTrace();
-                }
-            }
         }
     }
 }

--- a/src/main/java/com/buuz135/togetherforever/action/recovery/ReskillableLevelUpOfflineRecovery.java
+++ b/src/main/java/com/buuz135/togetherforever/action/recovery/ReskillableLevelUpOfflineRecovery.java
@@ -69,7 +69,7 @@ public class ReskillableLevelUpOfflineRecovery implements IOfflineSyncRecovery {
             recovery.setString("PlayerID", TogetherRegistries.getPlayerInformationID(playerInformation.getClass()));
             int id = 0;
             for (NBTTagCompound compound : offlineRecoveries.get(playerInformation)) {
-                recovery.setTag(id + "", compound);
+                recovery.setTag(Integer.toString(id), compound);
                 ++id;
             }
             tagCompound.setTag(uuid, recovery);
@@ -82,10 +82,10 @@ public class ReskillableLevelUpOfflineRecovery implements IOfflineSyncRecovery {
         offlineRecoveries.clear();
         for (String uuid : compound.getKeySet()) {
             NBTTagCompound recovery = compound.getCompoundTag(uuid);
-            Class plClass = TogetherRegistries.getPlayerInformationClass(recovery.getString("PlayerID"));
+            Class<? extends IPlayerInformation> plClass = TogetherRegistries.getPlayerInformationClass(recovery.getString("PlayerID"));
             if (plClass != null) {
                 try {
-                    IPlayerInformation info = (IPlayerInformation) plClass.newInstance();
+                    IPlayerInformation info = plClass.newInstance();
                     info.readFromNBT(recovery.getCompoundTag("ID"));
                     for (String id : recovery.getKeySet()) {
                         if (!id.equalsIgnoreCase("ID") && !id.equalsIgnoreCase("PlayerID")) {

--- a/src/main/java/com/buuz135/togetherforever/action/recovery/ReskillableLevelUpOfflineRecovery.java
+++ b/src/main/java/com/buuz135/togetherforever/action/recovery/ReskillableLevelUpOfflineRecovery.java
@@ -23,6 +23,9 @@ public class ReskillableLevelUpOfflineRecovery extends AbstractOfflineRecovery {
     @Override
     public void recoverMissingPlayer(IPlayerInformation playerInformation) {
         PlayerData data = PlayerDataHandler.get(playerInformation.getPlayer());
+        if (data == null) {
+            return;
+        }
         boolean changed = false;
         List<Map.Entry<IPlayerInformation, NBTTagCompound>> removeList = new ArrayList<>();
         for (Map.Entry<IPlayerInformation, NBTTagCompound> entry : new ArrayList<>(offlineRecoveries.entries())) {

--- a/src/main/java/com/buuz135/togetherforever/action/recovery/ReskillableUnlockableOfflineRecovery.java
+++ b/src/main/java/com/buuz135/togetherforever/action/recovery/ReskillableUnlockableOfflineRecovery.java
@@ -3,6 +3,7 @@ package com.buuz135.togetherforever.action.recovery;
 import codersafterdark.reskillable.api.ReskillableRegistries;
 import codersafterdark.reskillable.api.data.PlayerData;
 import codersafterdark.reskillable.api.data.PlayerDataHandler;
+import codersafterdark.reskillable.api.data.PlayerSkillInfo;
 import codersafterdark.reskillable.api.requirement.RequirementCache;
 import codersafterdark.reskillable.api.requirement.TraitRequirement;
 import codersafterdark.reskillable.api.unlockable.Unlockable;
@@ -21,17 +22,21 @@ public class ReskillableUnlockableOfflineRecovery extends AbstractOfflineRecover
 
     @Override
     public void recoverMissingPlayer(IPlayerInformation playerInformation) {
+        PlayerData data = PlayerDataHandler.get(playerInformation.getPlayer());
+        if (data == null) {
+            return;
+        }
+        boolean changed = false;
         List<Map.Entry<IPlayerInformation, NBTTagCompound>> removeList = new ArrayList<>();
         for (Map.Entry<IPlayerInformation, NBTTagCompound> entry : new ArrayList<>(offlineRecoveries.entries())) {
             if (entry.getKey().getUUID().equals(playerInformation.getUUID())) {
                 String skillID = entry.getValue().getString("Unlock");
                 Unlockable unlockable = ReskillableRegistries.UNLOCKABLES.getValue(new ResourceLocation(skillID));
                 if (unlockable != null) {
-                    PlayerData data = PlayerDataHandler.get(playerInformation.getPlayer());
-                    if (data != null && !data.getSkillInfo(unlockable.getParentSkill()).isUnlocked(unlockable)) {
-                        data.getSkillInfo(unlockable.getParentSkill()).unlock(unlockable, playerInformation.getPlayer());
-                        data.saveAndSync();
-                        RequirementCache.invalidateCache(playerInformation.getUUID(), TraitRequirement.class);
+                    PlayerSkillInfo skillInfo = data.getSkillInfo(unlockable.getParentSkill());
+                    if (!skillInfo.isUnlocked(unlockable)) {
+                        skillInfo.unlock(unlockable, playerInformation.getPlayer());
+                        changed = true;
                     }
                 }
                 removeList.add(entry);
@@ -39,6 +44,10 @@ public class ReskillableUnlockableOfflineRecovery extends AbstractOfflineRecover
         }
         for (Map.Entry<IPlayerInformation, NBTTagCompound> entry : removeList) {
             offlineRecoveries.remove(entry.getKey(), entry.getValue());
+        }
+        if (changed) {
+            data.saveAndSync();
+            RequirementCache.invalidateCache(playerInformation.getUUID(), TraitRequirement.class);
         }
     }
 }

--- a/src/main/java/com/buuz135/togetherforever/action/recovery/ReskillableUnlockableOfflineRecovery.java
+++ b/src/main/java/com/buuz135/togetherforever/action/recovery/ReskillableUnlockableOfflineRecovery.java
@@ -6,6 +6,7 @@ import codersafterdark.reskillable.api.data.PlayerDataHandler;
 import codersafterdark.reskillable.api.data.PlayerSkillInfo;
 import codersafterdark.reskillable.api.requirement.RequirementCache;
 import codersafterdark.reskillable.api.requirement.TraitRequirement;
+import codersafterdark.reskillable.api.toast.ToastHelper;
 import codersafterdark.reskillable.api.unlockable.Unlockable;
 import com.buuz135.togetherforever.api.IPlayerInformation;
 import net.minecraft.nbt.NBTTagCompound;
@@ -37,6 +38,7 @@ public class ReskillableUnlockableOfflineRecovery extends AbstractOfflineRecover
                     if (!skillInfo.isUnlocked(unlockable)) {
                         skillInfo.unlock(unlockable, playerInformation.getPlayer());
                         changed = true;
+                        ToastHelper.sendUnlockableToast(playerInformation.getPlayer(), unlockable);
                     }
                 }
                 removeList.add(entry);

--- a/src/main/java/com/buuz135/togetherforever/action/recovery/ReskillableUnlockableOfflineRecovery.java
+++ b/src/main/java/com/buuz135/togetherforever/action/recovery/ReskillableUnlockableOfflineRecovery.java
@@ -71,7 +71,7 @@ public class ReskillableUnlockableOfflineRecovery implements IOfflineSyncRecover
             recovery.setString("PlayerID", TogetherRegistries.getPlayerInformationID(playerInformation.getClass()));
             int id = 0;
             for (NBTTagCompound compound : offlineRecoveries.get(playerInformation)) {
-                recovery.setTag(id + "", compound);
+                recovery.setTag(Integer.toString(id), compound);
                 ++id;
             }
             tagCompound.setTag(uuid, recovery);
@@ -84,10 +84,10 @@ public class ReskillableUnlockableOfflineRecovery implements IOfflineSyncRecover
         offlineRecoveries.clear();
         for (String uuid : compound.getKeySet()) {
             NBTTagCompound recovery = compound.getCompoundTag(uuid);
-            Class plClass = TogetherRegistries.getPlayerInformationClass(recovery.getString("PlayerID"));
+            Class<? extends IPlayerInformation> plClass = TogetherRegistries.getPlayerInformationClass(recovery.getString("PlayerID"));
             if (plClass != null) {
                 try {
-                    IPlayerInformation info = (IPlayerInformation) plClass.newInstance();
+                    IPlayerInformation info = plClass.newInstance();
                     info.readFromNBT(recovery.getCompoundTag("ID"));
                     for (String id : recovery.getKeySet()) {
                         if (!id.equalsIgnoreCase("ID") && !id.equalsIgnoreCase("PlayerID")) {

--- a/src/main/java/com/buuz135/togetherforever/api/ISyncAction.java
+++ b/src/main/java/com/buuz135/togetherforever/api/ISyncAction.java
@@ -8,7 +8,7 @@ import java.util.List;
  * @param <T> The Object type that the action is based on
  * @param <S> The IOfflineRecovery for the ISyncAction
  */
-public interface ISyncAction<T extends Object, S extends IOfflineSyncRecovery> {
+public interface ISyncAction<T, S extends IOfflineSyncRecovery> {
 
     /**
      * Triggers a sync of the action returning a list of PlayersInformation the were offline for the sync

--- a/src/main/java/com/buuz135/togetherforever/api/TogetherForeverAPI.java
+++ b/src/main/java/com/buuz135/togetherforever/api/TogetherForeverAPI.java
@@ -128,18 +128,18 @@ public class TogetherForeverAPI {
      * Creates an invite to join a team
      *
      * @param sender         The player that sends the invite
-     * @param reciever       The player that recieves the invite
+     * @param receiver       The player that receives the invite
      * @param announceInvite true if the player that gets the invite needs to get a notification
      * @return The created invite
      */
-    public TeamInvite createTeamInvite(IPlayerInformation sender, IPlayerInformation reciever, boolean announceInvite) {
-        TeamInvite invite = new TeamInvite(sender, reciever);
+    public TeamInvite createTeamInvite(IPlayerInformation sender, IPlayerInformation receiver, boolean announceInvite) {
+        TeamInvite invite = new TeamInvite(sender, receiver);
         if (announceInvite) {
             ITextComponent accept = new TextComponentString("[ACCEPT]");
             accept.getStyle().setBold(true).setColor(TextFormatting.GREEN).setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/tf accept " + sender.getName())).setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new TextComponentString("Click to accept")));
             ITextComponent decline = new TextComponentString("[DECLINE]");
             decline.getStyle().setBold(true).setColor(TextFormatting.RED).setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/tf decline " + sender.getName())).setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new TextComponentString("Click to accept")));
-            reciever.getPlayer().sendMessage(new TextComponentString("You have been invited to join " + sender.getName() + "'s team. Click ")
+            receiver.getPlayer().sendMessage(new TextComponentString("You have been invited to join " + sender.getName() + "'s team. Click ")
                     .appendSibling(accept).appendText(" ").appendSibling(decline));
         }
         teamInvites.add(invite);

--- a/src/main/java/com/buuz135/togetherforever/api/action/EventSyncAction.java
+++ b/src/main/java/com/buuz135/togetherforever/api/action/EventSyncAction.java
@@ -47,13 +47,13 @@ public abstract class EventSyncAction<T extends PlayerEvent, S extends IOfflineS
         ITogetherTeam team = TogetherForeverAPI.getInstance().getPlayerTeam(event.getEntityPlayer().getUniqueID());
         if (team != null) {
             TogetherForever.LOGGER.warn("Found team: " + team.getTeamName() + ". Contains this players:");
-            team.getPlayers().forEach(iPlayerInformation -> TogetherForever.LOGGER.warn(iPlayerInformation.getUUID().toString() + ":" + iPlayerInformation.getName()));
+            team.getPlayers().forEach(iPlayerInformation -> TogetherForever.LOGGER.warn(iPlayerInformation.getUUID().toString() + ':' + iPlayerInformation.getName()));
             TogetherForever.LOGGER.warn("Starting to trigger sync");
             List<IPlayerInformation> playerLeft = triggerSync(event, team);
             TogetherForever.LOGGER.warn("Sync triggered with " + playerLeft.size() + " players not being synced:");
             NBTTagCompound compound = transformEventToNBT(event);
             for (IPlayerInformation information : playerLeft) {
-                TogetherForever.LOGGER.warn(information.getUUID().toString() + ":" + information.getName());
+                TogetherForever.LOGGER.warn(information.getUUID().toString() + ':' + information.getName());
                 TogetherForeverAPI.getInstance().addPlayerToOfflineRecovery(recovery, information, compound);
             }
         }
@@ -70,7 +70,7 @@ public abstract class EventSyncAction<T extends PlayerEvent, S extends IOfflineS
     }
 
     /**
-     * Transforms an event into a NBTTagCompound so it can be stored in the world for the IOfflineSyncRecovey
+     * Transforms an event into a NBTTagCompound so it can be stored in the world for the IOfflineSyncRecovery
      *
      * @param event The event to transform
      * @return The transformed NBTTagCompound of the Event

--- a/src/main/java/com/buuz135/togetherforever/api/action/EventSyncAction.java
+++ b/src/main/java/com/buuz135/togetherforever/api/action/EventSyncAction.java
@@ -41,19 +41,19 @@ public abstract class EventSyncAction<T extends PlayerEvent, S extends IOfflineS
     @SubscribeEvent(receiveCanceled = true)
     public void onEvent(T event) {
         if (!event.getClass().equals(eventClass)) return;
-        TogetherForever.LOGGER.warn("Triggering event class: " + event.getClass().toString());
+        TogetherForever.LOGGER.debug("Triggering event class: " + event.getClass().toString());
         if (TogetherForeverAPI.getInstance().getWorld() == null) return;
-        TogetherForever.LOGGER.warn("World is not null");
+        TogetherForever.LOGGER.debug("World is not null");
         ITogetherTeam team = TogetherForeverAPI.getInstance().getPlayerTeam(event.getEntityPlayer().getUniqueID());
         if (team != null) {
-            TogetherForever.LOGGER.warn("Found team: " + team.getTeamName() + ". Contains this players:");
-            team.getPlayers().forEach(iPlayerInformation -> TogetherForever.LOGGER.warn(iPlayerInformation.getUUID().toString() + ':' + iPlayerInformation.getName()));
-            TogetherForever.LOGGER.warn("Starting to trigger sync");
+            TogetherForever.LOGGER.debug("Found team: " + team.getTeamName() + ". Contains this players:");
+            team.getPlayers().forEach(iPlayerInformation -> TogetherForever.LOGGER.debug(iPlayerInformation.getUUID().toString() + ':' + iPlayerInformation.getName()));
+            TogetherForever.LOGGER.debug("Starting to trigger sync");
             List<IPlayerInformation> playerLeft = triggerSync(event, team);
-            TogetherForever.LOGGER.warn("Sync triggered with " + playerLeft.size() + " players not being synced:");
+            TogetherForever.LOGGER.debug("Sync triggered with " + playerLeft.size() + " players not being synced:");
             NBTTagCompound compound = transformEventToNBT(event);
             for (IPlayerInformation information : playerLeft) {
-                TogetherForever.LOGGER.warn(information.getUUID().toString() + ':' + information.getName());
+                TogetherForever.LOGGER.debug(information.getUUID().toString() + ':' + information.getName());
                 TogetherForeverAPI.getInstance().addPlayerToOfflineRecovery(recovery, information, compound);
             }
         }

--- a/src/main/java/com/buuz135/togetherforever/api/command/TogetherForeverCommand.java
+++ b/src/main/java/com/buuz135/togetherforever/api/command/TogetherForeverCommand.java
@@ -9,8 +9,10 @@ import net.minecraft.util.text.TextComponentString;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -25,32 +27,35 @@ public class TogetherForeverCommand extends CommandBase {
         command = this;
     }
 
+    @Nonnull
     @Override
     public String getName() {
         return "togetherforever";
     }
 
+    @Nonnull
     @Override
-    public String getUsage(ICommandSender sender) {
+    public String getUsage(@Nonnull ICommandSender sender) {
         StringBuilder builder = new StringBuilder("Usage: /tf <");
         for (SubCommandAction action : subCommandActions) {
-            builder.append(action.getSubCommandName()).append("|");
+            builder.append(action.getSubCommandName()).append('|');
         }
-        return builder.deleteCharAt(builder.length() - 1).append(">").toString();
+        return builder.deleteCharAt(builder.length() - 1).append('>').toString();
     }
 
+    @Nonnull
     @Override
     public List<String> getAliases() {
         return Arrays.asList("tf", "together");
     }
 
     @Override
-    public void execute(MinecraftServer server, ICommandSender sender, String[] args) {
+    public void execute(@Nonnull MinecraftServer server, @Nonnull ICommandSender sender, @Nonnull String[] args) {
         if (args.length >= 1) {
             for (SubCommandAction action : subCommandActions) {
                 if (action.getSubCommandName().equalsIgnoreCase(args[0])) {
                     if (!action.execute(server, sender, args)) {
-                        sender.sendMessage(new TextComponentString(TextFormatting.RED + "Usage: /tf " + action.getSubCommandName() + " " + action.getUsage() + " - " + action.getInfo()));
+                        sender.sendMessage(new TextComponentString(TextFormatting.RED + "Usage: /tf " + action.getSubCommandName() + ' ' + action.getUsage() + " - " + action.getInfo()));
                         sender.sendMessage(new TextComponentString(TextFormatting.RED + "Use '/tf help' for more information!"));
                     }
                     return;
@@ -60,6 +65,7 @@ public class TogetherForeverCommand extends CommandBase {
         sender.sendMessage(new TextComponentString(TextFormatting.RED + getUsage(sender)));
     }
 
+    @Nonnull
     @Override
     public List<String> getTabCompletions(MinecraftServer server, ICommandSender sender, String[] args, @Nullable BlockPos targetPos) {
         if (args.length == 1)
@@ -69,7 +75,7 @@ public class TogetherForeverCommand extends CommandBase {
                 return FMLCommonHandler.instance().getMinecraftServerInstance().getPlayerList().getPlayers().stream().map(EntityPlayer::getName).collect(Collectors.toList());
             }
         }
-        return Arrays.asList();
+        return Collections.emptyList();
     }
 
     @Override

--- a/src/main/java/com/buuz135/togetherforever/api/data/DataManager.java
+++ b/src/main/java/com/buuz135/togetherforever/api/data/DataManager.java
@@ -6,6 +6,7 @@ import com.buuz135.togetherforever.api.ITogetherTeam;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.storage.WorldSavedData;
 
+import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -29,7 +30,7 @@ public class DataManager extends WorldSavedData {
     }
 
     @Override
-    public void readFromNBT(NBTTagCompound nbt) {
+    public void readFromNBT(@Nonnull NBTTagCompound nbt) {
         teams = new ArrayList<>();
         //
         NBTTagCompound raw = nbt.getCompoundTag(NAME);
@@ -38,10 +39,10 @@ public class DataManager extends WorldSavedData {
         for (String teamNames : teamCompound.getKeySet()) {
             NBTTagCompound team = teamCompound.getCompoundTag(teamNames);
             String teamID = team.getString("TeamID");
-            Class aClass = TogetherRegistries.getTogetherTeamClass(teamID);
+            Class<? extends ITogetherTeam> aClass = TogetherRegistries.getTogetherTeamClass(teamID);
             if (aClass != null) {
                 try {
-                    ITogetherTeam togetherTeam = (ITogetherTeam) aClass.newInstance();
+                    ITogetherTeam togetherTeam = aClass.newInstance();
                     togetherTeam.readFromNBT(team.getCompoundTag("Value"));
                     teams.add(togetherTeam);
                 } catch (InstantiationException | IllegalAccessException e) {
@@ -65,8 +66,9 @@ public class DataManager extends WorldSavedData {
         }
     }
 
+    @Nonnull
     @Override
-    public NBTTagCompound writeToNBT(NBTTagCompound compound) {
+    public NBTTagCompound writeToNBT(@Nonnull NBTTagCompound compound) {
         NBTTagCompound custom = new NBTTagCompound();
         //TEAM SAVING
         NBTTagCompound teamCompound = new NBTTagCompound();

--- a/src/main/java/com/buuz135/togetherforever/api/data/DataManager.java
+++ b/src/main/java/com/buuz135/togetherforever/api/data/DataManager.java
@@ -53,10 +53,10 @@ public class DataManager extends WorldSavedData {
         //OFFLINE RECOVERY READING
         NBTTagCompound offlineRecovery = nbt.getCompoundTag(RECOVERY);
         for (String key : offlineRecovery.getKeySet()) {
-            ISyncAction action = TogetherRegistries.getSyncActionFromID(key);
+            ISyncAction<?, ? extends IOfflineSyncRecovery> action = TogetherRegistries.getSyncActionFromID(key);
             if (action != null) {
                 try {
-                    IOfflineSyncRecovery recovery = (IOfflineSyncRecovery) action.getOfflineRecovery().newInstance();
+                    IOfflineSyncRecovery recovery = action.getOfflineRecovery().newInstance();
                     recovery.readFromNBT(offlineRecovery.getCompoundTag(key));
                     recoveries.add(recovery);
                 } catch (InstantiationException | IllegalAccessException e) {

--- a/src/main/java/com/buuz135/togetherforever/api/data/DefaultTogetherTeam.java
+++ b/src/main/java/com/buuz135/togetherforever/api/data/DefaultTogetherTeam.java
@@ -35,9 +35,7 @@ public class DefaultTogetherTeam implements ITogetherTeam {
 
     @Override
     public void removePlayer(IPlayerInformation playerInformation) {
-        if (playersInformation.contains(playerInformation)) {
-            playersInformation.remove(playerInformation);
-        }
+        playersInformation.remove(playerInformation);
     }
 
     @Override
@@ -57,10 +55,10 @@ public class DefaultTogetherTeam implements ITogetherTeam {
         compound.setString("Name", teamName);
         compound.setString("Owner", owner.toString());
         for (IPlayerInformation information : playersInformation) {
-            NBTTagCompound informationCompund = new NBTTagCompound();
-            informationCompund.setString("PlayerID", TogetherRegistries.getPlayerInformationID(information.getClass()));
-            informationCompund.setTag("Value", information.getNBTTag());
-            compound.setTag(information.getUUID().toString(), informationCompund);
+            NBTTagCompound informationCompound = new NBTTagCompound();
+            informationCompound.setString("PlayerID", TogetherRegistries.getPlayerInformationID(information.getClass()));
+            informationCompound.setTag("Value", information.getNBTTag());
+            compound.setTag(information.getUUID().toString(), informationCompound);
         }
         return compound;
     }
@@ -72,10 +70,10 @@ public class DefaultTogetherTeam implements ITogetherTeam {
         for (String key : compound.getKeySet()) {
             if (key.equalsIgnoreCase("Name")) continue;
             NBTTagCompound informationCompound = compound.getCompoundTag(key);
-            Class plClass = TogetherRegistries.getPlayerInformationClass(informationCompound.getString("PlayerID"));
+            Class<? extends IPlayerInformation> plClass = TogetherRegistries.getPlayerInformationClass(informationCompound.getString("PlayerID"));
             if (plClass != null) {
                 try {
-                    IPlayerInformation info = (IPlayerInformation) plClass.newInstance();
+                    IPlayerInformation info = plClass.newInstance();
                     info.readFromNBT(informationCompound.getCompoundTag("Value"));
                     playersInformation.add(info);
                 } catch (InstantiationException | IllegalAccessException e) {

--- a/src/main/java/com/buuz135/togetherforever/api/data/TeamInvite.java
+++ b/src/main/java/com/buuz135/togetherforever/api/data/TeamInvite.java
@@ -1,9 +1,6 @@
 package com.buuz135.togetherforever.api.data;
 
-import com.buuz135.togetherforever.api.IPlayerInformation;
-import com.buuz135.togetherforever.api.ISyncAction;
-import com.buuz135.togetherforever.api.ITogetherTeam;
-import com.buuz135.togetherforever.api.TogetherForeverAPI;
+import com.buuz135.togetherforever.api.*;
 import net.minecraft.util.text.TextComponentString;
 import net.minecraft.util.text.TextFormatting;
 
@@ -43,7 +40,7 @@ public class TeamInvite {
                 receiver.getPlayer().sendMessage(new TextComponentString(TextFormatting.GREEN + "You have joined " + sender.getName() + "'s team."));
         }
         if (syncActions) {
-            for (ISyncAction action : TogetherRegistries.getSyncActions()) {
+            for (ISyncAction<?, ? extends IOfflineSyncRecovery> action : TogetherRegistries.getSyncActions()) {
                 action.syncJoinPlayer(receiver, sender);
             }
         }

--- a/src/main/java/com/buuz135/togetherforever/api/data/TeamInvite.java
+++ b/src/main/java/com/buuz135/togetherforever/api/data/TeamInvite.java
@@ -10,12 +10,12 @@ import net.minecraft.util.text.TextFormatting;
 public class TeamInvite {
 
     private final IPlayerInformation sender;
-    private final IPlayerInformation reciever;
+    private final IPlayerInformation receiver;
     private long createdTime;
 
-    public TeamInvite(IPlayerInformation sender, IPlayerInformation reciever) {
+    public TeamInvite(IPlayerInformation sender, IPlayerInformation receiver) {
         this.sender = sender;
-        this.reciever = reciever;
+        this.receiver = receiver;
         this.createdTime = System.currentTimeMillis();
     }
 
@@ -24,7 +24,7 @@ public class TeamInvite {
     }
 
     public IPlayerInformation getReciever() {
-        return reciever;
+        return receiver;
     }
 
     public void acceptInvite(boolean announce, boolean syncActions) {
@@ -37,16 +37,16 @@ public class TeamInvite {
         if (announce) {
             for (IPlayerInformation info : team.getPlayers()) {
                 if (info.getPlayer() != null)
-                    info.getPlayer().sendMessage(new TextComponentString(TextFormatting.GREEN + reciever.getName() + " has joined your team."));
+                    info.getPlayer().sendMessage(new TextComponentString(TextFormatting.GREEN + receiver.getName() + " has joined your team."));
             }
-            if (reciever.getPlayer() != null)
-                reciever.getPlayer().sendMessage(new TextComponentString(TextFormatting.GREEN + "You have joined " + sender.getName() + "'s team."));
+            if (receiver.getPlayer() != null)
+                receiver.getPlayer().sendMessage(new TextComponentString(TextFormatting.GREEN + "You have joined " + sender.getName() + "'s team."));
         }
         if (syncActions) {
             for (ISyncAction action : TogetherRegistries.getSyncActions()) {
-                action.syncJoinPlayer(reciever, sender);
+                action.syncJoinPlayer(receiver, sender);
             }
         }
-        TogetherForeverAPI.getInstance().addPlayerToTeam(team, reciever);
+        TogetherForeverAPI.getInstance().addPlayerToTeam(team, receiver);
     }
 }

--- a/src/main/java/com/buuz135/togetherforever/api/data/TogetherRegistries.java
+++ b/src/main/java/com/buuz135/togetherforever/api/data/TogetherRegistries.java
@@ -12,7 +12,7 @@ import java.util.Map;
 
 public class TogetherRegistries {
 
-    private static final HashMap<String, ISyncAction> SYNC_ACTION_REGISTRY = new HashMap<>();
+    private static final HashMap<String, ISyncAction<?, ? extends IOfflineSyncRecovery>> SYNC_ACTION_REGISTRY = new HashMap<>();
     private static final HashMap<String, Class<? extends ITogetherTeam>> TEAM_REGISTRY = new HashMap<>();
     private static final HashMap<String, Class<? extends IPlayerInformation>> PLAYER_REGISTRY = new HashMap<>();
 
@@ -22,7 +22,7 @@ public class TogetherRegistries {
      * @param id     The ID of the sync action
      * @param action The ISyncAction to be registered
      */
-    public static void registerSyncAction(String id, ISyncAction action) {
+    public static void registerSyncAction(String id, ISyncAction<?, ? extends IOfflineSyncRecovery> action) {
         TogetherForever.LOGGER.info("Registering SyncAction with id " + id + " and class " + action.getClass().getName());
         SYNC_ACTION_REGISTRY.put(id, action);
     }
@@ -46,7 +46,7 @@ public class TogetherRegistries {
      * @param id The id of the SyncAction
      * @return the SyncAction, null if it doesn't exist
      */
-    public static ISyncAction getSyncActionFromID(String id) {
+    public static ISyncAction<?, ? extends IOfflineSyncRecovery> getSyncActionFromID(String id) {
         if (SYNC_ACTION_REGISTRY.containsKey(id)) {
             return SYNC_ACTION_REGISTRY.get(id);
         }
@@ -127,7 +127,7 @@ public class TogetherRegistries {
         return null;
     }
 
-    public static Collection<ISyncAction> getSyncActions() {
+    public static Collection<ISyncAction<?, ? extends IOfflineSyncRecovery>> getSyncActions() {
         return SYNC_ACTION_REGISTRY.values();
     }
 }

--- a/src/main/java/com/buuz135/togetherforever/command/AcceptInviteCommand.java
+++ b/src/main/java/com/buuz135/togetherforever/command/AcceptInviteCommand.java
@@ -24,13 +24,13 @@ public class AcceptInviteCommand extends SubCommandAction {
     public boolean execute(MinecraftServer server, ICommandSender sender, String[] args) {
         if (args.length > 1) {
             try {
-                EntityPlayerMP inviteReciever = CommandBase.getCommandSenderAsPlayer(sender);
+                EntityPlayerMP inviteReceiver = CommandBase.getCommandSenderAsPlayer(sender);
                 EntityPlayerMP inviteSender = TogetherForeverAPI.getInstance().getPlayer(args[1]);
-                if (inviteSender != null && inviteReciever != inviteSender) {
-                    IPlayerInformation infoReciever = DefaultPlayerInformation.createInformation(inviteReciever);
+                if (inviteSender != null && inviteReceiver != inviteSender) {
+                    IPlayerInformation infoReceiver = DefaultPlayerInformation.createInformation(inviteReceiver);
                     IPlayerInformation infoSender = DefaultPlayerInformation.createInformation(inviteSender);
                     for (TeamInvite invite : TogetherForeverAPI.getInstance().getTeamInvites()) {
-                        if (invite.getSender().equals(infoSender) && invite.getReciever().equals(infoReciever)) {
+                        if (invite.getSender().equals(infoSender) && invite.getReciever().equals(infoReceiver)) {
                             invite.acceptInvite(true, true);
                             TogetherForeverAPI.getInstance().getTeamInvites().remove(invite);
                             return true;

--- a/src/main/java/com/buuz135/togetherforever/command/DeclineInviteCommand.java
+++ b/src/main/java/com/buuz135/togetherforever/command/DeclineInviteCommand.java
@@ -24,15 +24,15 @@ public class DeclineInviteCommand extends SubCommandAction {
     public boolean execute(MinecraftServer server, ICommandSender sender, String[] args) {
         if (args.length > 1) {
             try {
-                EntityPlayerMP inviteReciever = CommandBase.getCommandSenderAsPlayer(sender);
+                EntityPlayerMP inviteReceiver = CommandBase.getCommandSenderAsPlayer(sender);
                 EntityPlayerMP inviteSender = TogetherForeverAPI.getInstance().getPlayer(args[1]);
-                if (inviteSender != null && inviteReciever != inviteSender) {
-                    IPlayerInformation infoReciever = DefaultPlayerInformation.createInformation(inviteReciever);
+                if (inviteSender != null && inviteReceiver != inviteSender) {
+                    IPlayerInformation infoReceiver = DefaultPlayerInformation.createInformation(inviteReceiver);
                     IPlayerInformation infoSender = DefaultPlayerInformation.createInformation(inviteSender);
                     for (TeamInvite invite : TogetherForeverAPI.getInstance().getTeamInvites()) {
-                        if (invite.getSender().equals(infoSender) && invite.getReciever().equals(infoReciever)) {
-                            inviteReciever.sendMessage(new TextComponentString(TextFormatting.RED + "You have declined the invite."));
-                            inviteSender.sendMessage(new TextComponentString(TextFormatting.RED + inviteReciever.getName() + " has declined the invite!"));
+                        if (invite.getSender().equals(infoSender) && invite.getReciever().equals(infoReceiver)) {
+                            inviteReceiver.sendMessage(new TextComponentString(TextFormatting.RED + "You have declined the invite."));
+                            inviteSender.sendMessage(new TextComponentString(TextFormatting.RED + inviteReceiver.getName() + " has declined the invite!"));
                             TogetherForeverAPI.getInstance().getTeamInvites().remove(invite);
                             return true;
                         }

--- a/src/main/java/com/buuz135/togetherforever/command/ForceSyncCommand.java
+++ b/src/main/java/com/buuz135/togetherforever/command/ForceSyncCommand.java
@@ -1,9 +1,6 @@
 package com.buuz135.togetherforever.command;
 
-import com.buuz135.togetherforever.api.IPlayerInformation;
-import com.buuz135.togetherforever.api.ISyncAction;
-import com.buuz135.togetherforever.api.ITogetherTeam;
-import com.buuz135.togetherforever.api.TogetherForeverAPI;
+import com.buuz135.togetherforever.api.*;
 import com.buuz135.togetherforever.api.command.SubCommandAction;
 import com.buuz135.togetherforever.api.data.DefaultPlayerInformation;
 import com.buuz135.togetherforever.api.data.TogetherRegistries;
@@ -32,7 +29,7 @@ public class ForceSyncCommand extends SubCommandAction {
                     EntityPlayerMP playerMP = playerInformation.getPlayer();
                     if (playerMP != null && !senderPlayer.getUniqueID().equals(playerMP.getUniqueID())) {
                         sender.sendMessage(new TextComponentString(TextFormatting.GOLD + "Trying to sync data from " + playerMP.getName() + " please don't hurt yourself in the process!"));
-                        for (ISyncAction action : TogetherRegistries.getSyncActions()) {
+                        for (ISyncAction<?, ? extends IOfflineSyncRecovery> action : TogetherRegistries.getSyncActions()) {
                             action.syncJoinPlayer(DefaultPlayerInformation.createInformation(senderPlayer), playerInformation);
                         }
                     }

--- a/src/main/java/com/buuz135/togetherforever/command/HelpCommand.java
+++ b/src/main/java/com/buuz135/togetherforever/command/HelpCommand.java
@@ -19,7 +19,7 @@ public class HelpCommand extends SubCommandAction {
             sender.sendMessage(new TextComponentString(TextFormatting.GOLD + "Together Forever Commands: "));
             for (SubCommandAction action : TogetherForeverCommand.command.getSubCommandActions()) {
                 if (!action.getSubCommandName().equals(this.getSubCommandName()))
-                    sender.sendMessage(new TextComponentString(TextFormatting.BLUE + " /tf " + action.getSubCommandName() + " " + getUsage() + TextFormatting.GRAY + "- " + TextFormatting.AQUA + action.getInfo()));
+                    sender.sendMessage(new TextComponentString(TextFormatting.BLUE + " /tf " + action.getSubCommandName() + ' ' + getUsage() + TextFormatting.GRAY + "- " + TextFormatting.AQUA + action.getInfo()));
             }
         }
         return true;

--- a/src/main/java/com/buuz135/togetherforever/command/TeamInfoCommand.java
+++ b/src/main/java/com/buuz135/togetherforever/command/TeamInfoCommand.java
@@ -51,10 +51,10 @@ public class TeamInfoCommand extends SubCommandAction {
 
     private String getFormatedName(IPlayerInformation playerInformation, boolean online, boolean owner, boolean yourself) {
         StringBuilder builder = new StringBuilder(" - ");
-        if (yourself) builder.append(TextFormatting.GOLD + "[");
-        builder.append((online ? TextFormatting.GREEN : TextFormatting.RED) + playerInformation.getName());
-        if (yourself) builder.append(TextFormatting.GOLD + "]");
-        if (owner) builder.append(TextFormatting.DARK_RED + "*");
+        if (yourself) builder.append(TextFormatting.GOLD).append('[');
+        builder.append(online ? TextFormatting.GREEN : TextFormatting.RED).append(playerInformation.getName());
+        if (yourself) builder.append(TextFormatting.GOLD).append(']');
+        if (owner) builder.append(TextFormatting.DARK_RED).append('*');
         return builder.toString();
     }
 }

--- a/src/main/java/com/buuz135/togetherforever/command/TeamInfoCommand.java
+++ b/src/main/java/com/buuz135/togetherforever/command/TeamInfoCommand.java
@@ -30,7 +30,7 @@ public class TeamInfoCommand extends SubCommandAction {
             }
             sender.sendMessage(new TextComponentString(togetherTeam.getTeamName() + " team information:"));
             for (IPlayerInformation playerInformation : togetherTeam.getPlayers()) {
-                sender.sendMessage(new TextComponentString(getFormatedName(playerInformation, playerInformation.getPlayer() != null, playerInformation.getUUID().equals(togetherTeam.getOwner()), senderMP.getUniqueID().equals(playerInformation.getUUID()))));
+                sender.sendMessage(new TextComponentString(getFormattedName(playerInformation, playerInformation.getPlayer() != null, playerInformation.getUUID().equals(togetherTeam.getOwner()), senderMP.getUniqueID().equals(playerInformation.getUUID()))));
             }
             return true;
         } catch (PlayerNotFoundException e) {
@@ -49,7 +49,7 @@ public class TeamInfoCommand extends SubCommandAction {
         return "Gets the players of your team";
     }
 
-    private String getFormatedName(IPlayerInformation playerInformation, boolean online, boolean owner, boolean yourself) {
+    private String getFormattedName(IPlayerInformation playerInformation, boolean online, boolean owner, boolean yourself) {
         StringBuilder builder = new StringBuilder(" - ");
         if (yourself) builder.append(TextFormatting.GOLD).append('[');
         builder.append(online ? TextFormatting.GREEN : TextFormatting.RED).append(playerInformation.getName());

--- a/src/main/java/com/buuz135/togetherforever/command/TogetherForeverDebug.java
+++ b/src/main/java/com/buuz135/togetherforever/command/TogetherForeverDebug.java
@@ -3,25 +3,28 @@ package com.buuz135.togetherforever.command;
 import com.buuz135.togetherforever.TogetherForever;
 import com.buuz135.togetherforever.api.TogetherForeverAPI;
 import net.minecraft.command.CommandBase;
-import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.command.PlayerNotFoundException;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.server.MinecraftServer;
 
+import javax.annotation.Nonnull;
+
 public class TogetherForeverDebug extends CommandBase {
+    @Nonnull
     @Override
     public String getName() {
         return "tfdebug";
     }
 
+    @Nonnull
     @Override
-    public String getUsage(ICommandSender sender) {
+    public String getUsage(@Nonnull ICommandSender sender) {
         return "tfdebug";
     }
 
     @Override
-    public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException {
+    public void execute(@Nonnull MinecraftServer server, @Nonnull ICommandSender sender, @Nonnull String[] args) {
         TogetherForever.LOGGER.info(TogetherForeverAPI.getInstance().getDataManager(server.getWorld(0)).writeToNBT(new NBTTagCompound()));
     }
 

--- a/src/main/java/com/buuz135/togetherforever/utils/AnnotationHelper.java
+++ b/src/main/java/com/buuz135/togetherforever/utils/AnnotationHelper.java
@@ -9,7 +9,7 @@ import java.util.stream.Collectors;
 
 public class AnnotationHelper {
 
-    public static List<Class> getAnnotatedClasses(ASMDataTable data, Class<? extends Annotation> annotationClass) {
+    public static List<Class<?>> getAnnotatedClasses(ASMDataTable data, Class<? extends Annotation> annotationClass) {
         return data.getAll(annotationClass.getCanonicalName()).stream().map(data1 -> {
             try {
                 return Class.forName(data1.getClassName());


### PR DESCRIPTION
This pull contains a few different changes:

- I did a good bit of cleanup and fixing of IntelliJ's warnings
- I extracted the duplicate code for OfflineRecovery and put it in an abstract class so that it is easier to manage if any of it needs to be changed.
- I believe this also fixes #17 as I changed the debug information to be logged to the debug level instead of the warn level.
- I also modified the Reskillable Compat to be more accurate about what level it is trying to set someone to, as well as not forcing Reskillable to save and sync until it is done with the changes it is making. I hope this will fix some of the minor desync issues I experienced in the past with the Reskillable integration but I am not sure as it is hard to test. Another side affect of this is that if someone uses a command to set their level then it will properly also have the rest of the team get their levels increased instead of only having their level go up by one. This falls back on just giving one level if the new data tag is not there to not break backwards compatibility with existing worlds/saves.
- Sends Toast notifications to players when they level up or a new skill is unlocked (Reskillable)